### PR TITLE
Update FALLBACK_URL to /Web/JavaScript

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ var mdnio = {
   service: process.env.SERVICE || 'google',
   
   searchDomain: process.env.SEARCH_DOMAIN || 'developer.mozilla.org',
-  fallbackURL: process.env.FALLBACK_URL || 'https://developer.mozilla.org/en-US/docs/JavaScript',
+  fallbackURL: process.env.FALLBACK_URL || 'https://developer.mozilla.org/en-US/docs/Web/JavaScript',
 
   serviceURLs: {
     google: 'http://google.com/search?btnI&q=', // Use btnI to enable "I'm feeling lucky"


### PR DESCRIPTION
Avoid unnecessary redirect as https://developer.mozilla.org/en-US/docs/JavaScript redirects to https://developer.mozilla.org/en-US/docs/Web/JavaScript
