### PR TITLE
Use debug, cache redirects and split out config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+npm-debug.log

--- a/config.js
+++ b/config.js
@@ -1,0 +1,23 @@
+var mdnDomain   = 'developer.mozilla.org';
+var mdnHomepage = 'https://developer.mozilla.org/en-US/docs/Web/JavaScript';
+
+/*
+  Environment variables:
+    PORT: The port to run the server on
+    SERVICE: The search service to use. ('google' or 'bing')
+    SEARCH_DOMAIN: The domain to search
+    FALLBACK_URL: The default URL for empty queries
+*/
+
+module.exports = {
+  port: process.env.PORT || 3000,
+  domain: process.env.SEARCH_DOMAIN || mdnDomain,
+  service: process.env.SERVICE || 'google',
+  fallbackUrl: process.env.FALLBACK_URL || mdnHomepage,
+
+  services: {
+    google: 'https://www.google.com/search?btnI&q=%s',
+    bing: 'http://www.bing.com/search?q=%s',
+    ddg: 'https://duckduckgo.com/?q=%21%20%s'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "description": "Short URLs for MDN",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },
   "repository": {
@@ -23,10 +22,22 @@
     "url",
     "redirection"
   ],
+  "contributors": [
+    {
+      "name": "Blake Embrey",
+      "email": "hello@blakeembrey.com",
+      "url": "http://blakeembrey.me"
+    }
+  ],
   "author": "Larry Davis",
   "license": "MIT",
   "readmeFilename": "README.md",
   "engines": {
-    "node": "0.8.x"
+    "node": "0.10.x"
+  },
+  "dependencies": {
+    "debug": "^2.1.1",
+    "lru-cache": "^2.5.0",
+    "request": "^2.51.0"
   }
 }


### PR DESCRIPTION
Refactored to a functional style. It’ll also now make requests from the server-side and cache locally. Moved config into another file.