### PR TITLE
Index page and OpenSearch support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,6 @@
-const debug = require('debug')('mdn.io')
 const { format } = require('util')
 
-function handler (service, query) {
-  debug('query %s', query || '(empty query)')
-
+function handler(service, query) {
   if (!query) return service.fallbackUrl
 
   return format(service.url, encodeURIComponent(`site:${service.domain} `) + query)

--- a/lib/public.js
+++ b/lib/public.js
@@ -63,14 +63,14 @@ module.exports = {
 </body>
 </html>`,
 
-  opensearchxml: `<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http:/www.mozilla.org/2006/browser/search/">
+  opensearchxml: `<OpenSearchDescription xmlns="https://a9.com/-/spec/opensearch/1.1/" xmlns:moz="https://www.mozilla.org/2006/browser/search/">
   <ShortName>MDN Web Docs</ShortName>
   <Description>Search MDN Web Docs</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <Image width="16" height="16" type="image/ico">
       https://developer.mozilla.org/favicon.ico
   </Image>
-  <Url type="text/html" method="get" template="http://mdn.io/{searchTerms}" />
-  <moz:SearchForm>http://mdn.io</moz:SearchForm>
+  <Url type="text/html" method="get" template="https://mdn.io/{searchTerms}" />
+  <moz:SearchForm>https://mdn.io</moz:SearchForm>
 </OpenSearchDescription>`
 }

--- a/lib/public.js
+++ b/lib/public.js
@@ -1,0 +1,76 @@
+module.exports = {
+  checkForPublic(query) {
+    if (!query || query == 'index.html') return { body: this.indexhtml, type: 'text/html' }
+    if (query == '.well-known/opensearch.xml') return { body: this.opensearchxml, type: 'text/xml' }
+    return null
+  },
+
+  indexhtml: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>mdn.io</title>
+  <link rel="search" type="application/opensearchdescription+xml" href="/.well-known/opensearch.xml" title="MDN Web Docs" />
+  <style>
+    body {
+      background-color: #252525;
+      color: white;
+      padding: 1rem;
+      display: grid;
+      grid-template-columns: 100%;
+      /* From MDN Web Docs */
+      font-family: Inter, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+    }
+
+    header {
+      text-align: center;
+      grid-row: 1;
+      grid-column: 1;
+    }
+
+    main {
+      text-align: center;
+      grid-row: 2;
+      grid-column: 1;
+    }
+
+    footer {
+      text-align: center;
+      grid-row: 3;
+      grid-column: 1;
+    }
+
+    a {
+      color: #539bf5;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>mdn.io</h1>
+  </header>
+  <main>
+    <p>mdn.io is the "I'm feeling lucky" URL shortener. mdn.io is fully open source, and you can find more info at its <a href="https://github.com/lazd/mdn.io#readme">README</a>.</p>
+  </main>
+  <footer>
+    <h3>Adding it as a search engine in your browser</h3>
+    <p>In some browsers, you can right click the address bar and click <code>Add MDN Web Docs</code>. From there, you can configure a keyword in your browsers settings.</p>
+    <p>Firefox: <a href="https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox#w_add-a-search-engine-from-the-address-bar" target="_blank">support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox</a></p>
+    <p>Chromium-based browsers:</p>
+  </footer>
+</body>
+</html>`,
+
+  opensearchxml: `<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http:/www.mozilla.org/2006/browser/search/">
+  <ShortName>MDN Web Docs</ShortName>
+  <Description>Search MDN Web Docs</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/ico">
+      https://developer.mozilla.org/favicon.ico
+  </Image>
+  <Url type="text/html" method="get" template="http://mdn.io/{searchTerms}" />
+  <moz:SearchForm>http://mdn.io</moz:SearchForm>
+</OpenSearchDescription>`
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,16 +1,24 @@
 const debug = require('debug')('mdn.io')
 const { createServer } = require('http')
+const { Response } = require('servie')
 const { createHandler } = require('servie-http')
 const { redirect } = require('servie-redirect')
 const { getURL } = require('servie-url')
 const handler = require('./index')
 const config = require('./config')
+const public = require('./public')
 const port = process.env.PORT || 3000
 
 const server = module.exports = createServer(createHandler(req => {
   const url = getURL(req)
 
-  return redirect(req, handler(config, url.pathname.substr(1)), 303)
+  const query = url.pathname.substr(1);
+  debug('query %s', query || '(empty query)')
+
+  const check = public.checkForPublic(query);
+  if (check != null) return new Response(check.body, { statusCode: 200, headers: { 'Content-Type': check.type + '; charset=UTF-8' } })
+
+  return redirect(req, handler(config, query), 303)
 }))
 
 if (!module.parent) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,5 +1,7 @@
+const debug = require('debug')('mdn.io')
 const handler = require('./index')
 const config = require('./config')
+const public = require('./public')
 
 addEventListener('fetch', event => {
   event.respondWith(redirect(event.request))
@@ -8,5 +10,11 @@ addEventListener('fetch', event => {
 function redirect(request) {
   const url = new URL(request.url)
 
-  return Response.redirect(handler(config, url.pathname.substr(1)), 303)
+  const query = url.pathname.substr(1);
+  debug('query %s', query || '(empty query)')
+
+  const check = public.checkForPublic(query);
+  if (check != null) return new Response(check.body, { status: 200, headers: { 'Content-Type': check.type + '; charset=UTF-8' } })
+
+  return Response.redirect(handler(config, query), 303)
 }


### PR DESCRIPTION
Here's a very basic index page, with support for OpenSearch. However, I think there are a few things that need to be done before merging:
- Have a public directory and serve those files directory, instead of storing them all in a javascript object. I would have done this to start off with but I wasn't sure how Cloudflare Workers would behave or if it would allow that. We could maybe setup something with Webpack for this to include the files in the bundle.
- Remove repetition between the node.js server and worker code. The only difference between them is that servie uses `statusCode` and workers uses `status`.
- Properly test the worker code. I've only tested the node.js server.
- Improve the index page. It's not exactly very pretty right now and is in need of some major improvements. In addition, I wasn't sure how chromium based browsers handle OpenSearch, and they don't seem to have an article on it like Firefox does.